### PR TITLE
Wrong source fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 open source ActivityPub/fediverse server
 
-[![Version: 25.5.17.1~ynh1](https://img.shields.io/badge/Version-25.5.17.1~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/forte/)
+[![Version: 25.5.17.101~ynh1](https://img.shields.io/badge/Version-25.5.17.101~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/forte/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/forte"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Forte"
 description.en = "open source ActivityPub/fediverse server"
 description.fr = "Serveur ActivityPub/fediverse open source"
 
-version = "25.5.17.1~ynh1"
+version = "25.5.17.101~ynh1"
 
 maintainers = ["Papa Dragon"]
 
@@ -55,8 +55,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://codeberg.org/streams/streams/archive/v25.5.17.1.tar.gz"
-    sha256 = "24b630140b304921d0c387e59354d223850f6b8cb21b380e724e6e6b0036fc6d"
+    url = "https://codeberg.org/fortified/forte/archive/v25.5.17.tar.gz"
+    sha256 = "c3570c9e02592ce95fd3cd62ab1dc408dab9440c450995d92b178f9c6d7c8538"
 
     autoupdate.strategy = "latest_forgejo_tag"
     autoupdate.version_regex = "^v(.*)$"


### PR DESCRIPTION
## Problem

- Previous code update used a wrong repo in manifest.toml (streams repo, which forte was forked from)

## Solution

- Use relevant repo in manifest.toml.
(package version is renamed as 25.5.17.101~ynh1 while the repo version is actually 25.5.17)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
