### PR TITLE
We let the system generate .env.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 open source ActivityPub/fediverse server
 
-[![Version: 26.5.27~ynh1](https://img.shields.io/badge/Version-26.5.27~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/forte/)
+[![Version: 26.5.27~ynh2](https://img.shields.io/badge/Version-26.5.27~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/forte/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/forte"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/env.local
+++ b/conf/env.local
@@ -1,1 +1,0 @@
-DATABASE_URL='mysql://__DB_USER__:__DB_PWD__@localhost/__DB_NAME__?serverVersion=__DB_VERS__&charset=utf8mb4';

--- a/conf/htconfig.sample.php
+++ b/conf/htconfig.sample.php
@@ -12,13 +12,13 @@
 
 // Then set the following for your MySQL installation
 
-$db_host = 'localhost'; // Use 'localhost' if you aren't using a remote server
+$db_host = 'localhost';
 $db_port = 0;                    // leave 0 for default or set your port
 $db_user = '__DB_USER__';
 $db_pass = '__DB_PWD__';
 $db_data = '__DB_NAME__';
 $db_type = 0; // use 1 for postgres, 0 for mysql
-$db_vers = '__DB_VERS__'; // Required for doctrine
+$db_vers = '__DB_VERS__';
 
 /*
  * Notice: Many of the following settings will be available in the admin panel

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Forte"
 description.en = "open source ActivityPub/fediverse server"
 description.fr = "Serveur ActivityPub/fediverse open source"
 
-version = "26.5.27~ynh1"
+version = "26.5.27~ynh2"
 
 maintainers = ["Papa Dragon"]
 

--- a/scripts/install
+++ b/scripts/install
@@ -86,9 +86,6 @@ ynh_script_progression "Provisionning database..."
 
 ynh_mysql_db_shell < $install_dir/install/schema_mysql.sql
 
-# Doctrine needs this
-ynh_config_add --template="env.local" --destination="$install_dir/.env.local"
-
 #=================================================
 # SET CRON JOBS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -13,7 +13,7 @@ source /usr/share/yunohost/helpers
 ynh_app_setting_set_default --key=email --value=$(ynh_user_get_info --username=$admin --key=mail)
 ynh_app_setting_set_default --key=upload --value="256M"
 ynh_app_setting_set_default --key=random_string --value="$(ynh_string_random --length=48)"
-ynh_app_setting_set_default --key=db_vers --value="$(mariadb -V | grep -Eo '[0-9]+\.[0-9]+' | head -n 1)"
+ynh_app_setting_set_default --key=db_vers --value="$(mariadb -V | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 
 #=================================================
 # CREATE A DATABASE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -81,9 +81,6 @@ ynh_script_progression "Pulling in external libraries with Composer..."
 
 ynh_composer_exec install --no-dev
 
-# Doctrine needs this
-ynh_config_add --template="env.local" --destination="$install_dir/.env.local"
-
 #=================================================
 # UPGRADE CRON JOB
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -43,9 +43,9 @@ chown -R "$app:www-data" "$install_dir"
 #=================================================
 if [[ -z $(ynh_app_setting_get --key=db_vers) ]]
 then
-	ynh_app_setting_set_default --key=db_vers --value="$(mariadb -V | grep -Eo '[0-9]+\.[0-9]+' | head -n 1)"
+	ynh_app_setting_set_default --key=db_vers --value="$(mariadb -V | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 else
-	ynh_app_setting_set --key=db_vers --value="$(mariadb -V | grep -Eo '[0-9]+\.[0-9]+' | head -n 1)"
+	ynh_app_setting_set --key=db_vers --value="$(mariadb -V | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -77,6 +77,13 @@ ynh_config_add_nginx
 #=================================================
 # COMPOSER
 #=================================================
+
+#Fix 26.5.27~ynh1. We need to remove a probable broken .env.local file
+if ynh_app_upgrading_from_version_before_or_equal_to 26.5.27~ynh1 && [[ $(grep '//\ ' $install_dir/.env.local) ]]
+then
+	ynh_safe_rm $install_dir/.env.local
+fi 
+
 ynh_script_progression "Pulling in external libraries with Composer..."
 
 ynh_composer_exec install --no-dev


### PR DESCRIPTION
## Problem

- System generated a faulty .env.local file, so previous version generated one but in the end an awful error 500 could appear, with various other bugs (cron job not running, federation issues…)

## Solution

- We made sure the .env.local is properly generated, by removing some comments that were picked while they shouldn’t have been
- Also fixed a mistaken MariaDB server version
- We get rid of the .env.local that was generated during install/update to 26.5.27~ynh1

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
